### PR TITLE
add port argument to browsersync fixes local server issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -280,6 +280,7 @@ gulp.task('serve', () => {
     * if browsersync refreshes are required set files to watch source files instead
     */
 
+    port: 4000,
     server: {
       baseDir: siteRoot
     }


### PR DESCRIPTION
Can you test this Chris?

For some reason my Gulp/BrowserSync is very consistent without this...